### PR TITLE
Messing up the license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Kramko messes with the license text
+
 MIT License
 
 Copyright (c) 2017 kramko


### PR DESCRIPTION
A simple mess up of the MIT license text